### PR TITLE
feat(web): enhance profile widget layout

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -502,3 +502,49 @@ body.compact .admin-panel {
 .role-help-card .text{ color:#4b5563; }
 .role-help-card .actions{ text-align:right; margin-top:14px; }
 
+/* === ui2: profile widget === */
+.profile-widget { position: relative; }
+
+.profile-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.profile-avatar {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 28px;
+  background: var(--color-accent-purple, #e9d5ff);
+  color: #4b5563;
+}
+
+.profile-name .title { font-weight: 700; font-size: 18px; line-height: 1.2; }
+.profile-name .muted { color: #6b7280; font-size: 14px; }
+
+.profile-role {
+  position: absolute; top: 8px; right: 8px;
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin-top: 12px;
+}
+
+.profile-grid .label  { color: #6b7280; font-size: 14px; }
+.profile-grid .value  { font-weight: 500; }
+
+.profile-link { color: #0ea5e9; text-decoration: none; }
+.profile-link:hover { text-decoration: underline; }
+
+.profile-actions { display: flex; justify-content: flex-end; margin-top: 12px; }
+
+/* small screens: одна колонка */
+@media (max-width: 640px) {
+  .profile-grid { grid-template-columns: 1fr; }
+}
+/* === /ui2: profile widget === */

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -6,19 +6,60 @@
     <div class="dashboard">
 
       {# — Профиль #}
-      <section class="card span-2" id="card-profile">
-        <div class="profile-info">
-          <div class="profile-item"><span class="profile-icon" title="Full name">👤</span><span>{{ profile_user.full_name or '—' }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="Username">🔖</span><span>{{ profile_user.username }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="Email">✉️</span><span>{{ profile_user.email or 'не указано' }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="Телефон">📞</span><span>{{ profile_user.phone or 'не указан' }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="День рождения">🎂</span><span>{{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="Язык">🌐</span><span>{{ profile_user.language or 'не указан' }}</span></div>
-          <div class="profile-item"><span class="profile-icon" title="Роль">🎭</span>
-            <button type="button" class="role-badge" data-role="{{ profile_user.role }}">{{ profile_user.role }}</button>
+      <section class="card span-2 profile-widget" id="card-profile">
+        <div class="profile-header">
+          <div class="profile-avatar" aria-hidden="true">👤</div>
+          <div class="profile-name">
+            <div class="title">{{ profile_user.full_name or profile_user.username }}</div>
+            <div class="muted">@{{ profile_user.username }}</div>
+          </div>
+          <button type="button"
+                  class="role-badge profile-role"
+                  data-role="{{ profile_user.role }}">{{ profile_user.role }}</button>
+        </div>
+
+        <div class="profile-grid">
+          <div class="item">
+            <div class="label">Email</div>
+            <div class="value">
+              {% if profile_user.email %}
+                <a class="profile-link" href="mailto:{{ profile_user.email }}">{{ profile_user.email }}</a>
+              {% else %}
+                <span class="ui2-muted">не указано</span>
+              {% endif %}
+            </div>
+          </div>
+
+          <div class="item">
+            <div class="label">Телефон</div>
+            <div class="value">
+              {% if profile_user.phone %}
+                {% set tel_clean = profile_user.phone
+                    |replace(' ', '')
+                    |replace('(', '')
+                    |replace(')', '')
+                    |replace('-', '') %}
+                <a class="profile-link" href="tel:{{ tel_clean }}">{{ profile_user.phone }}</a>
+              {% else %}
+                <span class="ui2-muted">не указан</span>
+              {% endif %}
+            </div>
+          </div>
+
+          <div class="item">
+            <div class="label">День рождения</div>
+            <div class="value">
+              {{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}
+            </div>
+          </div>
+
+          <div class="item">
+            <div class="label">Язык</div>
+            <div class="value">{{ profile_user.language or 'не указан' }}</div>
           </div>
         </div>
-        <div style="text-align:right;margin-top:12px;">
+
+        <div class="profile-actions">
           <a class="button" href="/profile/{{ profile_user.username }}">Подробнее</a>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- revamp dashboard profile widget with avatar, role badge, and 2-col grid
- append profile widget styles for layout and responsiveness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee02754e4832387d087b32c376af3