### PR TITLE
Use new auth templates and add password toggle

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -150,3 +150,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('click', onClick);
 })();
+
+// auth: toggle password
+(function(){
+  function onClick(e){
+    const btn = e.target.closest('.toggle-password');
+    if (!btn) return;
+    const input = btn.parentElement.querySelector('input.control[type="password"], input.control[type="text"]');
+    if (!input) return;
+    input.type = input.type === 'password' ? 'text' : 'password';
+  }
+  document.addEventListener('click', onClick);
+})();

--- a/web/templates/auth/create_web_account.html
+++ b/web/templates/auth/create_web_account.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set auth_page = true %}
 {% block title %}Создание аккаунта{% endblock %}
 {% block content %}
 <div class="ui-layout">

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set auth_page = true %}
 {% block title %}Вход{% endblock %}
 {% block content %}
   <div class="ui-layout">

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set auth_page = true %}
 {% block title %}Регистрация{% endblock %}
 {% block content %}
   <div class="ui-layout">

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -9,7 +9,7 @@
 <body>
     {% include "_icons.html" %}
     <header class="top-bar">
-        {% include "header.html" %}
+        {% if not auth_page %}{% include "header.html" %}{% endif %}
     </header>
     {% block content %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- add idempotent password toggle script
- hide main header on auth pages
- render new auth login/register templates with Telegram login link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5772314c832387dc62a4d48950e8