### PR TITLE
Add auth tab switching and route redirects

### DIFF
--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -51,11 +51,24 @@ def verify_telegram_login(data: Dict[str, str]) -> bool:
     return auth_date > 0 and (time.time() - auth_date) <= S.SESSION_MAX_AGE
 
 
-@router.get("", response_class=HTMLResponse)
-async def auth_page(request: Request) -> HTMLResponse:
-    context = base_context()
-    context.update({"telegram_id": request.cookies.get("telegram_id")})
-    return templates.TemplateResponse(request, "auth.html", context)
+@router.get("/auth")
+async def auth_get(request: Request):
+    return templates.TemplateResponse(request, "auth.html", {"now_ts": int(time.time())})
+
+
+@router.get("/login", include_in_schema=False)
+async def login_redirect():
+    return RedirectResponse("/auth#login", status_code=302)
+
+
+@router.get("/register", include_in_schema=False)
+async def register_redirect():
+    return RedirectResponse("/auth#register", status_code=302)
+
+
+@router.get("/restore", include_in_schema=False)
+async def restore_redirect():
+    return RedirectResponse("/auth#restore", status_code=302)
 
 
 @router.post("/login")

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -162,3 +162,38 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   document.addEventListener('click', onClick);
 })();
+
+// auth: tab switcher on /auth
+(function(){
+const tabs = Array.from(document.querySelectorAll('.auth-tabs .tab'));
+const forms = {
+login: document.querySelector('.form-login'),
+register: document.querySelector('.form-register'),
+restore: document.querySelector('.form-restore'),
+};
+if (!tabs.length || !forms.login) return;
+
+function activate(name){
+Object.keys(forms).forEach(k=>{
+forms[k]?.classList.toggle('is-hidden', k!==name);
+});
+tabs.forEach(t=>{
+t.classList.toggle('is-active', t.dataset.tab===name);
+t.setAttribute('aria-selected', String(t.dataset.tab===name));
+});
+// для закладки и глубоких ссылок
+if (location.hash !== '#'+name) history.replaceState(null,'','#'+name);
+}
+
+// клики по табам
+document.addEventListener('click', (e)=>{
+const t = e.target.closest('.auth-tabs .tab');
+const j = e.target.closest('[data-tab-jump]');
+if (t){ e.preventDefault(); activate(t.dataset.tab); }
+if (j){ e.preventDefault(); activate(j.dataset.tabJump); }
+});
+
+// при загрузке из hash
+const hash = (location.hash||'').replace('#','');
+if (hash && forms[hash]) activate(hash); else activate('login');
+})();


### PR DESCRIPTION
## Summary
- add client-side auth tab switching with hash handling
- implement /auth route and redirects from legacy endpoints

## Testing
- `flake8 --max-line-length=120 web/routes/auth.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af62d24c408323b46cd5fac27e2577