### PR TITLE
Improve FastAPI lifespan and systemd logging

### DIFF
--- a/deploy/systemd/leonidpro-web.service
+++ b/deploy/systemd/leonidpro-web.service
@@ -8,7 +8,10 @@ Group=devs
 WorkingDirectory=%E{LEONIDPRO_WORKDIR}
 EnvironmentFile=%E{LEONIDPRO_WORKDIR}/.env
 Environment=PATH=%E{LEONIDPRO_VENV}/bin
-ExecStart=%E{LEONIDPRO_VENV}/bin/uvicorn web:app --host 0.0.0.0 --port 5800
+Environment=PYTHONUNBUFFERED=1
+Environment=UVICORN_LOG_LEVEL=debug
+Environment=PYTHONASYNCIODEBUG=1
+ExecStart=%E{LEONIDPRO_VENV}/bin/uvicorn web:app --host 0.0.0.0 --port 5800 --lifespan=on --log-level debug
 
 Restart=on-failure
 RestartSec=3s


### PR DESCRIPTION
## Summary
- add robust lifespan handler with detailed logging and graceful shutdown
- ensure `init_models` logs begin/end and surfaces errors
- expand systemd web unit with unbuffered debug logging and explicit lifespan flag

## Testing
- `source ./venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1a5bff71883238fba8bd43ea90772