### PR TITLE
feat(header): persona-only UI backed by app_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@
 - Changelog: [CHANGELOG.md](./CHANGELOG.md)
 - Backlog: [BACKLOG.md](./BACKLOG.md)
 
-## UI Personas via app_settings: keys, fallback, admin editor
-Тексты интерфейса для отображения статуса доступа берутся из таблицы `app_settings` по ключам вида
-`ui.persona.<code>.<field>.<locale>`. Для каждого кода (`personal_brain`, `collective_consciousness`,
-`knowledge_keeper`, `system_architect`) доступны поля `label`, `tooltip`, `slogan` на русскоязычном ключе с
-фолбэком на английский. При отсутствии значений используются дефолты, прошитые в коде. Изменение строк
-доступно через админский экран `/admin/ui/personas`, который отправляет изменения на API
-`/api/v1/app-settings`.
+## Persona in header via app_settings (no roles in UI)
+Персональные тексты для шапки берутся из `app_settings` по ключам
+`ui.persona.<backendRole>.<field>.<locale>`, где `backendRole` — одна из `single|multiplayer|moderator|admin`.
+Пример:
+```
+ui.persona.single.label.ru = Второй мозг
+ui.persona.single.tooltip_md.ru = Ваш второй мозг — внешний контур памяти и обдумывания. [Что это?](https://trends.rbc.ru/trends/social/620393859a7947e531dafbcc)
+ui.persona.single.slogan.ru = Работайте во «втором мозге».
+```
+В UI показываются только `label`, `tooltip_md` (как безопасный markdown со ссылками) и `slogan` — без упоминания ролей.
 - [x] Каркас системы заметок: модель `Note` и `NoteService`.
 - [x] Каркас модуля заметок.
 - [x] Дашборд показывает профиль пользователя и его группы и проекты.

--- a/tests/web/test_app_settings_api.py
+++ b/tests/web/test_app_settings_api.py
@@ -39,7 +39,7 @@ async def test_get_defaults_etag(client: AsyncClient):
     resp = await client.get('/api/v1/app-settings?prefix=ui.persona.')
     assert resp.status_code == 200
     data = resp.json()
-    assert data['entries']['ui.persona.personal_brain.label.ru'] == 'Личный мозг'
+    assert data['entries']['ui.persona.single.label.ru'] == 'Второй мозг'
     etag = resp.headers['ETag']
     resp2 = await client.get('/api/v1/app-settings?prefix=ui.persona.', headers={'If-None-Match': etag})
     assert resp2.status_code == 304
@@ -48,16 +48,16 @@ async def test_get_defaults_etag(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_put_settings(client: AsyncClient):
     admin_id = await _create_admin()
-    payload = {"entries": {"ui.persona.personal_brain.label.ru": "Новый мозг"}}
+    payload = {"entries": {"ui.persona.single.label.ru": "Новый мозг"}}
     resp = await client.put('/api/v1/app-settings', json=payload, headers={'Authorization': f'Bearer {admin_id}'})
     assert resp.status_code == 200
     resp_get = await client.get('/api/v1/app-settings?prefix=ui.persona.')
-    assert resp_get.json()['entries']['ui.persona.personal_brain.label.ru'] == 'Новый мозг'
+    assert resp_get.json()['entries']['ui.persona.single.label.ru'] == 'Новый мозг'
 
 
 @pytest.mark.asyncio
 async def test_put_validation(client: AsyncClient):
     admin_id = await _create_admin()
-    bad = {"entries": {"ui.persona.personal_brain.label.ru": "<bad>"}}
+    bad = {"entries": {"ui.persona.single.label.ru": "<bad>"}}
     resp = await client.put('/api/v1/app-settings', json=bad, headers={'Authorization': f'Bearer {admin_id}'})
     assert resp.status_code == 400

--- a/web/static/js/constants/personaDefaults.js
+++ b/web/static/js/constants/personaDefaults.js
@@ -1,46 +1,46 @@
 export const personaDefaults = {
     ru: {
-        personal_brain: {
-            label: "Личный мозг",
-            tooltip: "Пространство вашего разума.",
-            slogan: "Работайте в своём втором мозге."
+        single: {
+            label: "Второй мозг",
+            tooltipMd: "Ваш второй мозг — внешний контур памяти и обдумывания. [Что это?](https://trends.rbc.ru/trends/social/620393859a7947e531dafbcc)",
+            slogan: "Работайте во «втором мозге»."
         },
-        collective_consciousness: {
+        multiplayer: {
             label: "Коллективное сознание",
-            tooltip: "Вы — часть общего знания.",
-            slogan: "Собираем знания вместе."
+            tooltipMd: "Вы — часть общего знания.",
+            slogan: "Собираем знание вместе."
         },
-        knowledge_keeper: {
+        moderator: {
             label: "Хранитель знаний",
-            tooltip: "Поддерживайте порядок и ясность.",
+            tooltipMd: "Поддерживайте порядок и ясность.",
             slogan: "Помогаем команде понимать больше."
         },
-        system_architect: {
+        admin: {
             label: "Архитектор системы",
-            tooltip: "Вы задаёте правила системы.",
-            slogan: "Создавайте опоры для платформы."
+            tooltipMd: "Вы задаёте правила платформы.",
+            slogan: "Создавайте опоры для всей системы."
         }
     },
     en: {
-        personal_brain: {
-            label: "Personal Brain",
-            tooltip: "Your space of thought.",
+        single: {
+            label: "Second Brain",
+            tooltipMd: "Your external memory and thinking. [What is it?](https://trends.rbc.ru/trends/social/620393859a7947e531dafbcc)",
             slogan: "Work in your second brain."
         },
-        collective_consciousness: {
-            label: "Collective Consciousness",
-            tooltip: "You are part of shared knowledge.",
-            slogan: "Gathering knowledge together."
+        multiplayer: {
+            label: "Collective Mind",
+            tooltipMd: "You are part of shared knowledge.",
+            slogan: "Gather knowledge together."
         },
-        knowledge_keeper: {
+        moderator: {
             label: "Knowledge Keeper",
-            tooltip: "Maintain order and clarity.",
+            tooltipMd: "Maintain order and clarity.",
             slogan: "Helping the team understand more."
         },
-        system_architect: {
+        admin: {
             label: "System Architect",
-            tooltip: "You define the system rules.",
-            slogan: "Build the platform's foundations."
+            tooltipMd: "You set the platform rules.",
+            slogan: "Build foundations for the whole system."
         }
     }
 };

--- a/web/static/js/persona.js
+++ b/web/static/js/persona.js
@@ -4,14 +4,14 @@ const memory = {};
 function build(entries, locale) {
     var _a, _b, _c, _d, _e, _f;
     const fall = 'ru';
-    const codes = ['personal_brain', 'collective_consciousness', 'knowledge_keeper', 'system_architect'];
+    const codes = ['single', 'multiplayer', 'moderator', 'admin'];
     const result = {};
     for (const code of codes) {
         const key = (field) => `ui.persona.${code}.${field}.${locale}`;
         const fallKey = (field) => `ui.persona.${code}.${field}.${fall}`;
         result[code] = {
             label: (_b = (_a = entries[key('label')]) !== null && _a !== void 0 ? _a : entries[fallKey('label')]) !== null && _b !== void 0 ? _b : personaDefaults[fall][code].label,
-            tooltip: (_d = (_c = entries[key('tooltip')]) !== null && _c !== void 0 ? _c : entries[fallKey('tooltip')]) !== null && _d !== void 0 ? _d : personaDefaults[fall][code].tooltip,
+            tooltipMd: (_d = (_c = entries[key('tooltip_md')]) !== null && _c !== void 0 ? _c : entries[fallKey('tooltip_md')]) !== null && _d !== void 0 ? _d : personaDefaults[fall][code].tooltipMd,
             slogan: (_f = (_e = entries[key('slogan')]) !== null && _e !== void 0 ? _e : entries[fallKey('slogan')]) !== null && _f !== void 0 ? _f : personaDefaults[fall][code].slogan
         };
     }
@@ -55,14 +55,31 @@ export async function loadPersonaTexts(locale) {
 }
 // React components (lightweight)
 import { useEffect, useState } from 'react';
-export function PersonaBadge({ code, locale }) {
+function renderMarkdown(md) {
+    const re = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+    const out = [];
+    let lastIndex = 0;
+    let match;
+    while ((match = re.exec(md)) !== null) {
+        if (match.index > lastIndex)
+            out.push(md.slice(lastIndex, match.index));
+        out.push(_jsx("a", { href: match[2], target: "_blank", rel: "noopener noreferrer", children: match[1] }));
+        lastIndex = re.lastIndex;
+    }
+    if (lastIndex < md.length)
+        out.push(md.slice(lastIndex));
+    return out;
+}
+export function PersonaHeader({ role, fullName, locale }) {
     const [texts, setTexts] = useState(null);
+    const [open, setOpen] = useState(false);
     useEffect(() => { loadPersonaTexts(locale).then(setTexts); }, [locale]);
     if (!texts)
         return null;
-    const entry = texts[code];
-    const id = `persona-tip-${code}`;
-    return (_jsxs("span", { className: "persona-badge", "aria-describedby": id, children: [entry.label, _jsx("span", { id: id, role: "tooltip", className: "sr-only", children: entry.tooltip })] }));
+    const entry = texts[role];
+    const short = fullName.length > 24 ? fullName.slice(0, 24) + '…' : fullName;
+    const id = 'persona-pop';
+    return (_jsxs("div", { className: "persona-header", children: [_jsx("span", { className: "persona-badge", tabIndex: 0, "aria-haspopup": "dialog", "aria-describedby": id, onMouseEnter: () => setOpen(true), onMouseLeave: () => setOpen(false), onFocus: () => setOpen(true), onBlur: () => setOpen(false), children: entry.label }), _jsx("span", { className: "persona-name", children: short }), open && (_jsxs("div", { id: id, role: "dialog", className: "persona-popover", children: [_jsx("strong", { children: fullName }), _jsx("div", { children: renderMarkdown(entry.tooltipMd) }), _jsx("div", { className: "muted", children: entry.slogan })] }))] }));
 }
 export function StickySlogan({ code, locale }) {
     const [texts, setTexts] = useState(null);

--- a/web/static/ts/constants/personaDefaults.ts
+++ b/web/static/ts/constants/personaDefaults.ts
@@ -1,46 +1,46 @@
 export const personaDefaults = {
   ru: {
-    personal_brain: {
-      label: "Личный мозг",
-      tooltip: "Пространство вашего разума.",
-      slogan: "Работайте в своём втором мозге."
+    single: {
+      label: "Второй мозг",
+      tooltipMd: "Ваш второй мозг — внешний контур памяти и обдумывания. [Что это?](https://trends.rbc.ru/trends/social/620393859a7947e531dafbcc)",
+      slogan: "Работайте во «втором мозге»."
     },
-    collective_consciousness: {
+    multiplayer: {
       label: "Коллективное сознание",
-      tooltip: "Вы — часть общего знания.",
-      slogan: "Собираем знания вместе."
+      tooltipMd: "Вы — часть общего знания.",
+      slogan: "Собираем знание вместе."
     },
-    knowledge_keeper: {
+    moderator: {
       label: "Хранитель знаний",
-      tooltip: "Поддерживайте порядок и ясность.",
+      tooltipMd: "Поддерживайте порядок и ясность.",
       slogan: "Помогаем команде понимать больше."
     },
-    system_architect: {
+    admin: {
       label: "Архитектор системы",
-      tooltip: "Вы задаёте правила системы.",
-      slogan: "Создавайте опоры для платформы."
+      tooltipMd: "Вы задаёте правила платформы.",
+      slogan: "Создавайте опоры для всей системы."
     }
   },
   en: {
-    personal_brain: {
-      label: "Personal Brain",
-      tooltip: "Your space of thought.",
+    single: {
+      label: "Second Brain",
+      tooltipMd: "Your external memory and thinking. [What is it?](https://trends.rbc.ru/trends/social/620393859a7947e531dafbcc)",
       slogan: "Work in your second brain."
     },
-    collective_consciousness: {
-      label: "Collective Consciousness",
-      tooltip: "You are part of shared knowledge.",
-      slogan: "Gathering knowledge together."
+    multiplayer: {
+      label: "Collective Mind",
+      tooltipMd: "You are part of shared knowledge.",
+      slogan: "Gather knowledge together."
     },
-    knowledge_keeper: {
+    moderator: {
       label: "Knowledge Keeper",
-      tooltip: "Maintain order and clarity.",
+      tooltipMd: "Maintain order and clarity.",
       slogan: "Helping the team understand more."
     },
-    system_architect: {
+    admin: {
       label: "System Architect",
-      tooltip: "You define the system rules.",
-      slogan: "Build the platform's foundations."
+      tooltipMd: "You set the platform rules.",
+      slogan: "Build foundations for the whole system."
     }
   }
 } as const;

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -47,7 +47,7 @@
           <div>
             <div class="text-muted">Роль</div>
             <div>
-              <button type="button" class="role-badge" data-role="{{ profile_user.role }}">{{ profile_user.role }}</button>
+              {# роль скрыта из UI #}
             </div>
           </div>
         </div>

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -15,11 +15,7 @@
               <div class="title">{{ profile_user.full_name or profile_user.username }}</div>
               <div class="muted">@{{ profile_user.username }}</div>
             </div>
-            <button type="button"
-                    class="role-badge profile-role"
-                    data-role="{{ profile_user.role }}">
-              <svg class="icon" aria-hidden="true"><use href="#i-shield"/></svg>&nbsp;{{ profile_user.role }}
-            </button>
+            {# роль скрыта из UI #}
           </div>
 
         <div class="profile-grid">


### PR DESCRIPTION
## Summary
- add persona texts (label, tooltip_md, slogan) for single/multiplayer/moderator/admin in app_settings with fallback defaults
- validate app_settings API and expose texts with ETag
- add PersonaHeader React component and hide role badges in templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20288ca64832383b0c685f01d8413