### PR TITLE
Add PARA calendar and notification domain models

### DIFF
--- a/core/services/para_repository.py
+++ b/core/services/para_repository.py
@@ -1,0 +1,246 @@
+"""Repositories for PARA calendar and notification models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.models import (
+    Area,
+    Project,
+    CalendarItem,
+    CalendarItemStatus,
+    Alarm,
+    NotificationChannel,
+    NotificationChannelKind,
+    ProjectNotification,
+    GCalLink,
+)
+from core.utils import utcnow
+from .nexus_service import CRUDService
+
+
+class AreaRepository(CRUDService[Area]):
+    """CRUD repository for :class:`Area`."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(Area, session)
+
+
+class ProjectRepository(CRUDService[Project]):
+    """CRUD repository for :class:`Project`."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(Project, session)
+
+    async def list(
+        self,
+        *,
+        owner_id: Optional[int] = None,
+        area_id: Optional[int] = None,
+        status: Optional[str] = None,
+    ) -> list[Project]:
+        stmt = select(Project)
+        if owner_id is not None:
+            stmt = stmt.where(Project.owner_id == owner_id)
+        if area_id is not None:
+            stmt = stmt.where(Project.area_id == area_id)
+        if status is not None:
+            stmt = stmt.where(Project.status == status)
+        res = await self.session.execute(stmt)
+        return res.scalars().all()
+
+
+class CalendarItemRepository(CRUDService[CalendarItem]):
+    """Repository for calendar items with PARA validation."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(CalendarItem, session)
+
+    async def create(
+        self,
+        *,
+        owner_id: int,
+        title: str,
+        start_at: datetime,
+        end_at: datetime | None = None,
+        project_id: int | None = None,
+        area_id: int | None = None,
+        status: CalendarItemStatus = CalendarItemStatus.planned,
+    ) -> CalendarItem:
+        if project_id is None and area_id is None:
+            raise ValueError("project_id or area_id is required")
+        if project_id is not None and area_id is None:
+            project = await self.session.get(Project, project_id)
+            if not project:
+                raise ValueError("project not found")
+            area_id = project.area_id
+        item = CalendarItem(
+            owner_id=owner_id,
+            title=title,
+            start_at=start_at,
+            end_at=end_at,
+            project_id=project_id,
+            area_id=area_id,
+            status=status,
+        )
+        self.session.add(item)
+        await self.session.flush()
+        return item
+
+    async def list(
+        self,
+        *,
+        owner_id: Optional[int] = None,
+        project_id: Optional[int] = None,
+        area_id: Optional[int] = None,
+        start_from: Optional[datetime] = None,
+        start_to: Optional[datetime] = None,
+        status: Optional[CalendarItemStatus] = None,
+    ) -> list[CalendarItem]:
+        stmt = select(CalendarItem)
+        if owner_id is not None:
+            stmt = stmt.where(CalendarItem.owner_id == owner_id)
+        if project_id is not None:
+            stmt = stmt.where(CalendarItem.project_id == project_id)
+        if area_id is not None:
+            stmt = stmt.where(CalendarItem.area_id == area_id)
+        if start_from is not None:
+            stmt = stmt.where(CalendarItem.start_at >= start_from)
+        if start_to is not None:
+            stmt = stmt.where(CalendarItem.start_at <= start_to)
+        if status is not None:
+            stmt = stmt.where(CalendarItem.status == status)
+        res = await self.session.execute(stmt.order_by(CalendarItem.start_at))
+        return res.scalars().all()
+
+    async def update(self, obj_id: int, **kwargs) -> CalendarItem | None:
+        obj = await super().update(obj_id, **kwargs)
+        if obj is not None:
+            obj.updated_at = utcnow()
+            await self.session.flush()
+        return obj
+
+
+class AlarmRepository(CRUDService[Alarm]):
+    """Repository for :class:`Alarm` objects."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(Alarm, session)
+
+    async def list(
+        self,
+        *,
+        item_id: Optional[int] = None,
+        due_from: Optional[datetime] = None,
+        due_to: Optional[datetime] = None,
+        is_sent: Optional[bool] = None,
+    ) -> list[Alarm]:
+        stmt = select(Alarm)
+        if item_id is not None:
+            stmt = stmt.where(Alarm.item_id == item_id)
+        if due_from is not None:
+            stmt = stmt.where(Alarm.trigger_at >= due_from)
+        if due_to is not None:
+            stmt = stmt.where(Alarm.trigger_at <= due_to)
+        if is_sent is not None:
+            stmt = stmt.where(Alarm.is_sent == is_sent)
+        res = await self.session.execute(stmt.order_by(Alarm.trigger_at))
+        return res.scalars().all()
+
+    async def update(self, obj_id: int, **kwargs) -> Alarm | None:
+        obj = await super().update(obj_id, **kwargs)
+        if obj is not None:
+            obj.updated_at = utcnow()
+            await self.session.flush()
+        return obj
+
+
+class ChannelRepository(CRUDService[NotificationChannel]):
+    """Repository for user notification channels."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(NotificationChannel, session)
+
+    async def list(
+        self,
+        *,
+        owner_id: Optional[int] = None,
+        kind: Optional[NotificationChannelKind] = None,
+        is_active: Optional[bool] = None,
+    ) -> list[NotificationChannel]:
+        stmt = select(NotificationChannel)
+        if owner_id is not None:
+            stmt = stmt.where(NotificationChannel.owner_id == owner_id)
+        if kind is not None:
+            stmt = stmt.where(NotificationChannel.kind == kind)
+        if is_active is not None:
+            stmt = stmt.where(NotificationChannel.is_active == is_active)
+        res = await self.session.execute(stmt)
+        return res.scalars().all()
+
+    async def update(self, obj_id: int, **kwargs) -> NotificationChannel | None:
+        obj = await super().update(obj_id, **kwargs)
+        if obj is not None:
+            obj.updated_at = utcnow()
+            await self.session.flush()
+        return obj
+
+
+class ProjectNotificationRepository(CRUDService[ProjectNotification]):
+    """Repository for project notification subscriptions."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(ProjectNotification, session)
+
+    async def list(
+        self,
+        *,
+        project_id: Optional[int] = None,
+        channel_id: Optional[int] = None,
+        is_enabled: Optional[bool] = None,
+    ) -> list[ProjectNotification]:
+        stmt = select(ProjectNotification)
+        if project_id is not None:
+            stmt = stmt.where(ProjectNotification.project_id == project_id)
+        if channel_id is not None:
+            stmt = stmt.where(ProjectNotification.channel_id == channel_id)
+        if is_enabled is not None:
+            stmt = stmt.where(ProjectNotification.is_enabled == is_enabled)
+        res = await self.session.execute(stmt)
+        return res.scalars().all()
+
+    async def update(self, obj_id: int, **kwargs) -> ProjectNotification | None:
+        obj = await super().update(obj_id, **kwargs)
+        if obj is not None:
+            obj.updated_at = utcnow()
+            await self.session.flush()
+        return obj
+
+
+class GCalLinkRepository(CRUDService[GCalLink]):
+    """Repository for external Google Calendar links."""
+
+    def __init__(self, session: Optional[AsyncSession] = None) -> None:
+        super().__init__(GCalLink, session)
+
+    async def list(
+        self,
+        *,
+        owner_id: Optional[int] = None,
+    ) -> list[GCalLink]:
+        stmt = select(GCalLink)
+        if owner_id is not None:
+            stmt = stmt.where(GCalLink.owner_id == owner_id)
+        res = await self.session.execute(stmt)
+        return res.scalars().all()
+
+    async def update(self, obj_id: int, **kwargs) -> GCalLink | None:
+        obj = await super().update(obj_id, **kwargs)
+        if obj is not None:
+            obj.updated_at = utcnow()
+            await self.session.flush()
+        return obj

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -38,6 +38,7 @@ from core.services.notification_service import (
     run_reminder_dispatcher,
     is_scheduler_enabled,
 )
+from . import para_schemas  # noqa: F401
 
 
 logger = logging.getLogger(__name__)

--- a/web/para_schemas.py
+++ b/web/para_schemas.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Pydantic schemas for PARA calendar and notification models."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+from core.models import CalendarItemStatus, NotificationChannelKind
+
+
+class AreaSchema(BaseModel):
+    id: int
+    name: str
+    color: str | None = None
+    parent_id: int | None = None
+    depth: int
+    slug: str
+    mp_path: str
+
+
+class ProjectSchema(BaseModel):
+    id: int
+    name: str
+    area_id: int
+    status: str
+
+
+class CalendarItemBase(BaseModel):
+    title: str
+    start_at: datetime
+    end_at: datetime | None = None
+    project_id: int | None = None
+    area_id: int | None = None
+    status: CalendarItemStatus = CalendarItemStatus.planned
+
+    @field_validator("area_id")
+    @classmethod
+    def validate_para(cls, v, info):
+        project_id = info.data.get("project_id") if hasattr(info, "data") else None
+        if v is None and project_id is None:
+            raise ValueError("project_id or area_id required")
+        return v
+
+
+class CalendarItemCreate(CalendarItemBase):
+    pass
+
+
+class CalendarItemRead(CalendarItemBase):
+    id: int
+    owner_id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class AlarmBase(BaseModel):
+    item_id: int
+    trigger_at: datetime
+    is_sent: bool = False
+
+
+class AlarmCreate(AlarmBase):
+    pass
+
+
+class AlarmRead(AlarmBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ChannelBase(BaseModel):
+    kind: NotificationChannelKind
+    address: str
+    is_active: bool = True
+
+
+class ChannelCreate(ChannelBase):
+    pass
+
+
+class ChannelRead(ChannelBase):
+    id: int
+    owner_id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectNotificationBase(BaseModel):
+    project_id: int
+    channel_id: int
+    is_enabled: bool = True
+
+
+class ProjectNotificationCreate(ProjectNotificationBase):
+    pass
+
+
+class ProjectNotificationRead(ProjectNotificationBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class GCalLinkBase(BaseModel):
+    calendar_id: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+
+
+class GCalLinkCreate(GCalLinkBase):
+    pass
+
+
+class GCalLinkRead(GCalLinkBase):
+    id: int
+    owner_id: int
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
## Summary
- add CalendarItem, Alarm, NotificationChannel, ProjectNotification and GCalLink models
- implement async repositories with PARA validation and filters
- expose Pydantic schemas for new domain types and import into app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2303da7408323b0174b2861e3ffe0