### PR TITLE
feat: add calendar item API stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Тайм‑трекер: модель `TimeEntry`, `TimeService`, веб‑API `/time`, страница UI, команды бота `/time_start`, `/time_stop`, `/time_list`.
 - Каркас системы напоминаний: модель `Reminder`, `ReminderService`, привязка к задачам.
 - Каркас календаря: модель `CalendarEvent`, `CalendarService`.
+- Базовые эндпоинты календаря `/api/v1/calendar/items` и генерация `feed.ics` (заглушки).
 - REST-эндпоинты `/api/v1/app-settings` и загрузка динамических персон UI через `app_settings`.
 - Персонализированная шапка с названием системы и подсказкой в зависимости от роли.
 

--- a/web/routes/projects.py
+++ b/web/routes/projects.py
@@ -64,6 +64,58 @@ async def create_project(payload: ProjectCreate, current_user: TgUser | None = D
     return ProjectResponse.from_model(p)
 
 
+# ---------------------------------------------------------------------------
+# Project notifications (placeholder)
+# ---------------------------------------------------------------------------
+
+
+class ProjectNotificationCreate(BaseModel):
+    """Bind a Telegram channel to a project with given rules."""
+
+    channel_id: int
+    rules: dict | None = None
+
+
+class ProjectNotificationResponse(ProjectNotificationCreate):
+    """Echo representation of a project notification binding."""
+
+    id: int | None = None
+
+
+@router.post(
+    "/{project_id}/notifications",
+    response_model=ProjectNotificationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_project_notification(
+    project_id: int,
+    payload: ProjectNotificationCreate,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    """Placeholder for creating project notification rules."""
+
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Notifications not implemented",
+    )
+
+
+@router.get(
+    "/{project_id}/notifications",
+    response_model=List[ProjectNotificationResponse],
+)
+async def list_project_notifications(
+    project_id: int, current_user: TgUser | None = Depends(get_current_tg_user)
+):
+    """Placeholder for listing project notification rules."""
+
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return []
+
+
 @ui_router.get("")
 async def projects_page(request: Request, current_user: WebUser | None = Depends(get_current_web_user)):
     context = {


### PR DESCRIPTION
## Summary
- scaffold calendar item CRUD endpoints and agenda/feed routes
- add placeholder project notification bindings
- extend calendar service helpers

## Testing
- `python -m venv venv && source venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b23047651883238945878d52831d19