### PR TITLE
feat: add Google Calendar integration skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,8 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=
 EMAIL_FROM=
+
+# Google Calendar
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GCAL_WEBHOOK_URL="http://localhost:5800/api/v1/integrations/google/webhook"

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,7 @@
 """Database models used by the application."""
 from enum import IntEnum, Enum as PyEnum
 from datetime import date
+import uuid
 
 from .db import bcrypt
 
@@ -23,6 +24,7 @@ from sqlalchemy import (
     Index,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from base import Base
 
@@ -634,6 +636,31 @@ class Link(Base):
     weight = Column(Float, default=1.0)
     decay = Column(Float, default=1.0)
     created_at = Column(DateTime, default=utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Google Calendar link
+# ---------------------------------------------------------------------------
+
+class GCalLink(Base):
+    """OAuth credentials and watch state for Google Calendar integration."""
+
+    __tablename__ = "gcal_links"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(PG_UUID(as_uuid=True), nullable=False)
+    google_calendar_id = Column(String, nullable=False)
+    access_token = Column(String, nullable=False)
+    refresh_token = Column(String, nullable=False)
+    scope = Column(String, nullable=False)
+    token_expiry = Column(DateTime(timezone=True), nullable=False)
+    sync_token = Column(String)
+    resource_id = Column(String)
+    channel_id = Column(String)
+    channel_expiry = Column(DateTime(timezone=True))
+    created_at = Column(DateTime(timezone=True), default=utcnow)
+    updated_at = Column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
+
 
 
 # ---------------------------------------------------------------------------

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -7,6 +7,13 @@ from .telegram_user_service import TelegramUserService
 from .time_service import TimeService
 from .web_user_service import WebUserService
 from .favorite_service import FavoriteService
+from .sync_gcal import (
+    generate_auth_url,
+    exchange_code,
+    save_link as save_gcal_link,
+    initial as gcal_initial,
+    incremental as gcal_incremental,
+)
 
 __all__ = [
     "NoteService",
@@ -16,4 +23,9 @@ __all__ = [
     "TimeService",
     "WebUserService",
     "FavoriteService",
+    "generate_auth_url",
+    "exchange_code",
+    "save_gcal_link",
+    "gcal_initial",
+    "gcal_incremental",
 ]

--- a/core/services/sync_gcal.py
+++ b/core/services/sync_gcal.py
@@ -1,0 +1,193 @@
+"""Google Calendar sync helpers."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+import uuid
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core import db
+from core.logger import logger
+from core.models import GCalLink
+from core.utils import utcnow
+
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+EVENTS_URL_TMPL = "https://www.googleapis.com/calendar/v3/calendars/{cal_id}/events"
+WATCH_URL_TMPL = EVENTS_URL_TMPL + "/watch"
+SCOPE = "https://www.googleapis.com/auth/calendar"
+
+
+async def _refresh_if_needed(link: GCalLink, session: AsyncSession) -> GCalLink:
+    from web.config import S
+
+    if link.token_expiry and link.token_expiry > utcnow() + timedelta(minutes=1):
+        return link
+    data = {
+        "client_id": S.GOOGLE_CLIENT_ID,
+        "client_secret": S.GOOGLE_CLIENT_SECRET,
+        "refresh_token": link.refresh_token,
+        "grant_type": "refresh_token",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(TOKEN_URL, data=data)
+        resp.raise_for_status()
+        payload = resp.json()
+    link.access_token = payload["access_token"]
+    expires_in = int(payload.get("expires_in", 3600))
+    link.token_expiry = utcnow() + timedelta(seconds=expires_in)
+    session.add(link)
+    await session.commit()
+    return link
+
+
+def generate_auth_url(state: str, redirect_uri: str) -> str:
+    from web.config import S
+
+    params = {
+        "client_id": S.GOOGLE_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": SCOPE,
+        "access_type": "offline",
+        "prompt": "consent",
+        "state": state,
+    }
+    return f"{AUTH_URL}?{urlencode(params)}"
+
+
+async def exchange_code(code: str, redirect_uri: str) -> dict[str, Any]:
+    from web.config import S
+
+    data = {
+        "code": code,
+        "client_id": S.GOOGLE_CLIENT_ID,
+        "client_secret": S.GOOGLE_CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "redirect_uri": redirect_uri,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(TOKEN_URL, data=data)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def save_link(
+    user_id: str,
+    google_calendar_id: str,
+    token_data: dict[str, Any],
+) -> GCalLink:
+    async with db.async_session() as session:
+        link = GCalLink(
+            user_id=user_id,
+            google_calendar_id=google_calendar_id,
+            access_token=token_data["access_token"],
+            refresh_token=token_data.get("refresh_token", ""),
+            scope=token_data.get("scope", ""),
+            token_expiry=utcnow() + timedelta(seconds=int(token_data.get("expires_in", 3600))),
+        )
+        session.add(link)
+        await session.commit()
+        await session.refresh(link)
+        return link
+
+
+async def get_link(user_id: str, calendar_id: str) -> GCalLink | None:
+    async with db.async_session() as session:
+        res = await session.execute(
+            select(GCalLink).where(
+                GCalLink.user_id == user_id,
+                GCalLink.google_calendar_id == calendar_id,
+            )
+        )
+        link = res.scalar_one_or_none()
+        if not link:
+            return None
+        return await _refresh_if_needed(link, session)
+
+
+async def initial(user_id: str, google_calendar_id: str) -> list[dict[str, Any]]:
+    link = await get_link(user_id, google_calendar_id)
+    if not link:
+        raise ValueError("not linked")
+    params = {
+        "timeMin": (utcnow() - timedelta(days=60)).isoformat(),
+        "timeMax": (utcnow() + timedelta(days=180)).isoformat(),
+        "singleEvents": True,
+        "showDeleted": True,
+    }
+    headers = {"Authorization": f"Bearer {link.access_token}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            EVENTS_URL_TMPL.format(cal_id=google_calendar_id),
+            params=params,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    async with db.async_session() as session:
+        link.sync_token = data.get("nextSyncToken")
+        session.add(link)
+        await session.commit()
+    items = data.get("items", [])
+    logger.info("gcal initial sync: %s items", len(items))
+    return items
+
+
+async def incremental(user_id: str, google_calendar_id: str) -> list[dict[str, Any]]:
+    link = await get_link(user_id, google_calendar_id)
+    if not link or not link.sync_token:
+        return await initial(user_id, google_calendar_id)
+    params = {
+        "syncToken": link.sync_token,
+        "singleEvents": True,
+        "showDeleted": True,
+    }
+    headers = {"Authorization": f"Bearer {link.access_token}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            EVENTS_URL_TMPL.format(cal_id=google_calendar_id),
+            params=params,
+            headers=headers,
+        )
+    if resp.status_code == 410:
+        logger.warning("gcal sync token expired, resyncing")
+        return await initial(user_id, google_calendar_id)
+    resp.raise_for_status()
+    data = resp.json()
+    async with db.async_session() as session:
+        link.sync_token = data.get("nextSyncToken")
+        session.add(link)
+        await session.commit()
+    items = data.get("items", [])
+    logger.info("gcal incremental sync: %s items", len(items))
+    return items
+
+
+async def start_watch(link: GCalLink) -> None:
+    from web.config import S
+
+    body = {
+        "id": link.channel_id or str(uuid.uuid4()),
+        "type": "webhook",
+        "address": S.GCAL_WEBHOOK_URL,
+    }
+    headers = {"Authorization": f"Bearer {link.access_token}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            WATCH_URL_TMPL.format(cal_id=link.google_calendar_id), json=body, headers=headers
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    link.channel_id = payload.get("id")
+    link.resource_id = payload.get("resourceId")
+    exp = payload.get("expiration")
+    if exp:
+        link.channel_expiry = datetime.fromtimestamp(int(exp) / 1000, tz=timezone.utc)
+    async with db.async_session() as session:
+        session.add(link)
+        await session.commit()

--- a/web/config.py
+++ b/web/config.py
@@ -39,6 +39,11 @@ class EnvSettings(BaseSettings):
     RECAPTCHA_SITE_KEY: Optional[str] = None
     RECAPTCHA_SECRET_KEY: Optional[str] = None
 
+    # Google Calendar
+    GOOGLE_CLIENT_ID: Optional[str] = None
+    GOOGLE_CLIENT_SECRET: Optional[str] = None
+    GCAL_WEBHOOK_URL: AnyHttpUrl | None = None  # type: ignore[assignment]
+
     # pydantic-settings v2 style configuration
     model_config = SettingsConfigDict(
         env_file=os.getenv("LEONIDPRO_ENV_FILE", ".env"),
@@ -154,6 +159,21 @@ class Settings:
     @property
     def RECAPTCHA_SITE_KEY(self):
         return self._env.RECAPTCHA_SITE_KEY
+
+    @property
+    def GOOGLE_CLIENT_ID(self):
+        return self._store.get("google.GOOGLE_CLIENT_ID") or self._env.GOOGLE_CLIENT_ID
+
+    @property
+    def GOOGLE_CLIENT_SECRET(self):
+        return self._store.get_secret("google.GOOGLE_CLIENT_SECRET") or self._env.GOOGLE_CLIENT_SECRET
+
+    @property
+    def GCAL_WEBHOOK_URL(self):
+        val = self._store.get("google.GCAL_WEBHOOK_URL")
+        if val:
+            return val
+        return str(self._env.GCAL_WEBHOOK_URL) if self._env.GCAL_WEBHOOK_URL else None
 
     @property
     def ADMIN_IDS(self):

--- a/web/routes/__init__.py
+++ b/web/routes/__init__.py
@@ -27,6 +27,7 @@ from .api.admin_settings import router as admin_settings_api
 from .api.app_settings import router as app_settings_api
 from .api.auth_webapp import router as auth_webapp_api
 from .api.user_favorites import router as user_favorites_api
+from .api.integrations_google import router as gcal_api
 
 # Монтирование под /api/v1
 api_router.include_router(tasks_api, prefix="/tasks", tags=["tasks"])
@@ -44,3 +45,4 @@ api_router.include_router(admin_settings_api, prefix="/admin_settings", tags=["a
 api_router.include_router(app_settings_api, prefix="/app-settings", tags=["app-settings"])
 api_router.include_router(auth_webapp_api, prefix="/auth", tags=["auth"])
 api_router.include_router(user_favorites_api, prefix="/user", tags=["user"])
+api_router.include_router(gcal_api, prefix="/integrations/google", tags=["integrations"])

--- a/web/routes/api/integrations_google.py
+++ b/web/routes/api/integrations_google.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import RedirectResponse, Response
+
+from core.logger import logger
+from core.models import WebUser
+from core.services import (
+    generate_auth_url,
+    exchange_code,
+    save_gcal_link,
+    gcal_incremental,
+)
+from web.config import S
+from web.dependencies import get_current_web_user
+
+router = APIRouter()
+
+
+@router.get("/connect")
+async def connect(current_user: WebUser | None = Depends(get_current_web_user)):
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    redirect_uri = f"{S.WEB_PUBLIC_URL.rstrip('/')}/api/v1/integrations/google/callback"
+    url = generate_auth_url(str(current_user.id), redirect_uri)
+    return RedirectResponse(url)
+
+
+@router.get("/callback")
+async def callback(
+    request: Request,
+    code: str,
+    state: str,
+    current_user: WebUser | None = Depends(get_current_web_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    redirect_uri = f"{S.WEB_PUBLIC_URL.rstrip('/')}/api/v1/integrations/google/callback"
+    token_data = await exchange_code(code, redirect_uri)
+    await save_gcal_link(str(current_user.id), "primary", token_data)
+    logger.info("gcal connected for user %s", current_user.id)
+    return {"ok": True}
+
+
+@router.post("/disconnect")
+async def disconnect(current_user: WebUser | None = Depends(get_current_web_user)):
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    # Simple removal of link
+    from core import db
+    from core.models import GCalLink
+    from sqlalchemy import delete
+
+    async with db.async_session() as session:
+        await session.execute(
+            delete(GCalLink).where(
+                GCalLink.user_id == str(current_user.id)
+            )
+        )
+        await session.commit()
+    logger.info("gcal disconnected for user %s", current_user.id)
+    return {"ok": True}
+
+
+@router.post("/webhook")
+async def webhook(request: Request):
+    token = request.headers.get("X-Goog-Channel-Token")
+    # In this simple implementation, we expect token to be user_id
+    if not token:
+        return Response(status_code=200)
+    try:
+        user_id = token.split(":", 1)[0]
+    except Exception:  # pragma: no cover
+        return Response(status_code=200)
+    await gcal_incremental(user_id, "primary")
+    logger.debug("gcal webhook processed for %s", user_id)
+    return Response(status_code=200)


### PR DESCRIPTION
## Summary
- add Google Calendar env settings
- scaffold sync service and model for Google Calendar
- expose API routes for OAuth flow and webhooks

## Testing
- `python -m venv venv && source venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2304f4e6083238410f61f05910651